### PR TITLE
Update ROS1.json

### DIFF
--- a/metadata/Ports/ROS1.json
+++ b/metadata/Ports/ROS1.json
@@ -171,7 +171,11 @@
                     "Transport": "ROS1",
                     "Protocol": "Publisher",
                     "Message": "&",
-                    "LinkEnabled": true
+                    "LinkEnabled": true,
+                    "Parameter": {
+                        "latch": false,
+                        "queue_size": 1
+                    },
                 }
             }
         },


### PR DESCRIPTION
- [BP-568](https://movai.atlassian.net/browse/BP-568): Support for sending latched topic in gd.oport api
    added support for Parameters for ROS1/Publisher

[BP-568]: https://movai.atlassian.net/browse/BP-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ